### PR TITLE
Handling unix signals

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/ramonmoraes/timer/cmd"
@@ -22,6 +24,35 @@ func main() {
 	}
 
 	waitTime := cmd.ParseTime(strings.Join(args, ""))
-	time.Sleep(waitTime)
-	cmd.PlayBeep(2 * time.Second)
+	shouldPlay := handleInterruptions(waitTime)
+
+	if shouldPlay {
+		cmd.PlayBeep(2 * time.Second)
+	}
+}
+
+func handleInterruptions(waitTime time.Duration) bool {
+	started := time.Now()
+
+	done := make(chan bool, 1)
+	// Wait default time expected time
+	go func() {
+		time.Sleep(waitTime)
+		done <- true
+	}()
+
+	// Custom handler for signals
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGSTOP)
+	go func() {
+		sig := <-sigs
+
+		executionTime := time.Now().Sub(started)
+		minutes := executionTime.Minutes()
+		seconds := executionTime.Seconds()
+		fmt.Printf("\n[%s] Timer runned for: %.0fm %.0fs\n", sig, minutes, seconds)
+		done <- false
+	}()
+
+	return <-done
 }

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func handleInterruptions(waitTime time.Duration) bool {
 	started := time.Now()
 
 	done := make(chan bool, 1)
-	// Wait default time expected time
+	// Wait default expected time
 	go func() {
 		time.Sleep(waitTime)
 		done <- true


### PR DESCRIPTION
This PR make the timer log the elapsed time whenever it's execution is stoped by a unix signal

e.g:
```bash
timer 30s
^C
[interrupt] Timer runned for: 0m 2s
...
```